### PR TITLE
Fix undefined reference to __version__ in setup.py.  Pylint showed an…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
 from setuptools import setup
 
-exec (open('dash_colorscales/version.py').read())
+main_ns = {}
+exec(open('dash_colorscales/version.py').read(), main_ns)
 
 setup(
     name='dash_colorscales',
-    version=__version__,
+    version=main_ns['__version__'],
     author='plotly',
     packages=['dash_colorscales'],
     include_package_data=True,


### PR DESCRIPTION
… undefined variable error. You can test this fix by changing the 'version' in version.py or setup.py and then running from the command line: python3 setup.py --version